### PR TITLE
Fix rubocop warnings in RabbitMQ services

### DIFF
--- a/app/services/rabbitmq_consumer.rb
+++ b/app/services/rabbitmq_consumer.rb
@@ -9,8 +9,9 @@ class RabbitmqConsumer
     queue = channel.queue(queue)
 
     queue.subscribe(block: true) do |_delivery_info, _properties, body|
-      puts "Mensagem recebida: #{body}"
+      Rails.logger.info "Mensagem recebida: #{body}"
       # Processar a mensagem aqui
     end
   end
 end
+

--- a/app/services/rabbitmq_producer.rb
+++ b/app/services/rabbitmq_producer.rb
@@ -12,3 +12,4 @@ class RabbitmqProducer
     connection.close
   end
 end
+


### PR DESCRIPTION
## Summary
- clean up RabbitMQ consumer/producer services

## Testing
- `bundle exec rspec`
- `bundle exec rubocop`

------
https://chatgpt.com/codex/tasks/task_e_684b59d33b608332a85e7757b60b1b97